### PR TITLE
Fix how gems are installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,11 @@ doc
 
 # bundler
 .bundle
-Gemfile.lock
 
 # juwelier generated
 pkg
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
+# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
 #
 # * Create a file at ~/.gitignore
 # * Include files you want ignored

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'vertebrae', '> 0.5'
-
-# Add dependencies to develop your gem here.
-# Include everything needed to run rake, tests, features, etc.
-group :development do
-  gem 'pry', '~> 0.10'
-  gem 'pry-byebug', '~> 3.4'
-  gem 'webmock', '~> 3.0', '>= 3.0.1'
-  gem 'rspec', '~> 3.6'
-  gem 'rdoc', "~> 3.12"
-  gem 'bundler'
-  gem 'juwelier'
-  gem 'simplecov', ">= 0"
-  gem 'rubocop'
-  gem 'rspec_junit_formatter'
-end
+# Specify dependencies in the gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,160 @@
+PATH
+  remote: .
+  specs:
+    identity-api-client (0.1.3)
+      vertebrae (> 0.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.3.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.1)
+    builder (3.2.4)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    diff-lcs (1.4.4)
+    docile (1.3.2)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
+    git (1.7.0)
+      rchardet (~> 1.8)
+    github_api (0.19.0)
+      addressable (~> 2.4)
+      descendants_tracker (~> 0.0.4)
+      faraday (>= 0.8, < 2)
+      hashie (~> 3.5, >= 3.5.2)
+      oauth2 (~> 1.0)
+    hashdiff (1.0.1)
+    hashie (3.6.0)
+    highline (2.0.3)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
+    json (1.8.6)
+    juwelier (2.4.9)
+      builder
+      bundler
+      git
+      github_api
+      highline
+      kamelcase (~> 0)
+      nokogiri
+      psych
+      rake
+      rdoc
+      semver2
+    jwt (2.2.1)
+    kamelcase (0.0.2)
+      semver2 (~> 3)
+    method_source (1.0.0)
+    mini_portile2 (2.4.0)
+    minitest (5.14.1)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    psych (3.2.0)
+    public_suffix (4.0.5)
+    rack (2.2.3)
+    rainbow (3.0.0)
+    rake (13.0.1)
+    rchardet (1.8.0)
+    rdoc (3.12.2)
+      json (~> 1.4)
+    regexp_parser (1.7.1)
+    rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
+    rubocop (0.89.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.1.0, < 1.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
+    ruby-progressbar (1.10.1)
+    safe_yaml (1.0.5)
+    semver2 (3.4.2)
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
+    unicode-display_width (1.7.0)
+    vertebrae (0.6.2)
+      activesupport (>= 5.1.4)
+      faraday (> 0.9.2)
+      faraday_middleware (> 0.12.2)
+      hashie (> 3.5.7)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    zeitwerk (2.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  identity-api-client!
+  juwelier
+  pry (~> 0.10)
+  pry-byebug (~> 3.4)
+  rdoc (~> 3.12)
+  rspec (~> 3.6)
+  rspec_junit_formatter
+  rubocop
+  simplecov
+  webmock (~> 3.0, >= 3.0.1)
+
+BUNDLED WITH
+   1.17.2

--- a/identity-api-client.gemspec
+++ b/identity-api-client.gemspec
@@ -46,43 +46,15 @@ Gem::Specification.new do |s|
   s.rubygems_version = "3.0.8".freeze
   s.summary = "API Client for 38 Degree's Identity API".freeze
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<vertebrae>.freeze, ["> 0.5"])
-      s.add_development_dependency(%q<pry>.freeze, ["~> 0.10"])
-      s.add_development_dependency(%q<pry-byebug>.freeze, ["~> 3.4"])
-      s.add_development_dependency(%q<webmock>.freeze, ["~> 3.0", ">= 3.0.1"])
-      s.add_development_dependency(%q<rspec>.freeze, ["~> 3.6"])
-      s.add_development_dependency(%q<rdoc>.freeze, ["~> 3.12"])
-      s.add_development_dependency(%q<bundler>.freeze, [">= 0"])
-      s.add_development_dependency(%q<juwelier>.freeze, [">= 0"])
-      s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
-      s.add_development_dependency(%q<rubocop>.freeze, [">= 0"])
-    else
-      s.add_dependency(%q<vertebrae>.freeze, ["> 0.5"])
-      s.add_dependency(%q<pry>.freeze, ["~> 0.10"])
-      s.add_dependency(%q<pry-byebug>.freeze, ["~> 3.4"])
-      s.add_dependency(%q<webmock>.freeze, ["~> 3.0", ">= 3.0.1"])
-      s.add_dependency(%q<rspec>.freeze, ["~> 3.6"])
-      s.add_dependency(%q<rdoc>.freeze, ["~> 3.12"])
-      s.add_dependency(%q<bundler>.freeze, [">= 0"])
-      s.add_dependency(%q<juwelier>.freeze, [">= 0"])
-      s.add_dependency(%q<simplecov>.freeze, [">= 0"])
-      s.add_dependency(%q<rubocop>.freeze, [">= 0"])
-    end
-  else
-    s.add_dependency(%q<vertebrae>.freeze, ["> 0.5"])
-    s.add_dependency(%q<pry>.freeze, ["~> 0.10"])
-    s.add_dependency(%q<pry-byebug>.freeze, ["~> 3.4"])
-    s.add_dependency(%q<webmock>.freeze, ["~> 3.0", ">= 3.0.1"])
-    s.add_dependency(%q<rspec>.freeze, ["~> 3.6"])
-    s.add_dependency(%q<rdoc>.freeze, ["~> 3.12"])
-    s.add_dependency(%q<bundler>.freeze, [">= 0"])
-    s.add_dependency(%q<juwelier>.freeze, [">= 0"])
-    s.add_dependency(%q<simplecov>.freeze, [">= 0"])
-    s.add_dependency(%q<rubocop>.freeze, [">= 0"])
-  end
+  s.add_runtime_dependency('vertebrae', ["> 0.5"])
+  s.add_development_dependency('pry', ["~> 0.10"])
+  s.add_development_dependency('pry-byebug', ["~> 3.4"])
+  s.add_development_dependency('webmock', ["~> 3.0", ">= 3.0.1"])
+  s.add_development_dependency('rspec', ["~> 3.6"])
+  s.add_development_dependency('rdoc', ["~> 3.12"])
+  s.add_development_dependency('bundler', [">= 0"])
+  s.add_development_dependency('juwelier', [">= 0"])
+  s.add_development_dependency('simplecov', [">= 0"])
+  s.add_development_dependency('rspec_junit_formatter', [">= 0"])
+  s.add_development_dependency('rubocop', [">= 0"])
 end
-


### PR DESCRIPTION
Simplify the dependencies in the gemspec so there are not 3 copies of
all the dependencies.

Don't put dependencies in the Gemfile, just the gemspec

Commit the Gemfile.lock file