### PR TITLE
Update Rdoc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,6 @@ GEM
     highline (2.0.3)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    json (1.8.6)
     juwelier (2.4.9)
       builder
       bundler
@@ -88,8 +87,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.1)
     rchardet (1.8.0)
-    rdoc (3.12.2)
-      json (~> 1.4)
+    rdoc (6.2.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
     rspec (3.9.0)
@@ -149,7 +147,7 @@ DEPENDENCIES
   juwelier
   pry (~> 0.10)
   pry-byebug (~> 3.4)
-  rdoc (~> 3.12)
+  rdoc (~> 6.2)
   rspec (~> 3.6)
   rspec_junit_formatter
   rubocop

--- a/identity-api-client.gemspec
+++ b/identity-api-client.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pry-byebug', ["~> 3.4"])
   s.add_development_dependency('webmock', ["~> 3.0", ">= 3.0.1"])
   s.add_development_dependency('rspec', ["~> 3.6"])
-  s.add_development_dependency('rdoc', ["~> 3.12"])
+  s.add_development_dependency('rdoc', ["~> 6.2"])
   s.add_development_dependency('bundler', [">= 0"])
   s.add_development_dependency('juwelier', [">= 0"])
   s.add_development_dependency('simplecov', [">= 0"])


### PR DESCRIPTION
It removes a dependency on a vulnerable version of json

Big jump, but rdoc still runs successfully