### PR TITLE
Dependabot CVE minimal patches.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.2)
+    activesupport (6.0.6.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -19,7 +19,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.10)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     descendants_tracker (0.0.4)
@@ -42,7 +42,7 @@ GEM
     hashdiff (1.0.1)
     hashie (3.6.0)
     highline (2.0.3)
-    i18n (1.8.5)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     juwelier (2.4.9)
       builder
@@ -60,12 +60,12 @@ GEM
     kamelcase (0.0.2)
       semver2 (~> 3)
     method_source (1.0.0)
-    mini_portile2 (2.8.0)
-    minitest (5.14.1)
+    mini_portile2 (2.8.1)
+    minitest (5.14.4)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    nokogiri (1.13.9)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oauth2 (1.4.4)
@@ -85,8 +85,8 @@ GEM
       pry (~> 0.13.0)
     psych (3.2.0)
     public_suffix (4.0.6)
-    racc (1.6.0)
-    rack (2.2.3)
+    racc (1.6.2)
+    rack (2.2.6.2)
     rainbow (3.0.0)
     rake (13.0.1)
     rchardet (1.8.0)
@@ -127,7 +127,7 @@ GEM
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
     thread_safe (0.3.6)
-    tzinfo (1.2.7)
+    tzinfo (1.2.11)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
     vertebrae (0.6.2)
@@ -139,7 +139,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.4.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -158,4 +158,4 @@ DEPENDENCIES
   webmock (~> 3.0, >= 3.0.1)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
Updating libs based on dependabot result. This is a very minimal change, just the patch numbers required to meet the minimum version. Several of the dependabot suggested bumps seems to have a low success rate reported. As this library does not have a super strong test suite and will be consumed as other projects as a gem the bumps have been kept to the minimum version to resolve the CVEs. All current should be resolved by this commit.